### PR TITLE
Add `network.address` and `game.version` server spec fields

### DIFF
--- a/apis/v1alpha1/groupversion_info.go
+++ b/apis/v1alpha1/groupversion_info.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"ricochet/polaris/apis"
+	"github.com/RicochetStudios/polaris/apis"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"

--- a/apis/v1alpha1/server_types.go
+++ b/apis/v1alpha1/server_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"net"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,6 +65,11 @@ type Network struct {
 	//
 	// +optional
 	Type NetworkType `json:"type"`
+
+	// The IP address of the server.
+	//
+	// +optional
+	Address net.IP `json:"address"`
 }
 
 // ServerSpec defines the desired state of the server.

--- a/apis/v1alpha1/server_types.go
+++ b/apis/v1alpha1/server_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"net"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -69,7 +67,7 @@ type Network struct {
 	// The IP address of the server.
 	//
 	// +optional
-	Address net.IP `json:"address"`
+	Address string `json:"address"`
 }
 
 // ServerSpec defines the desired state of the server.

--- a/apis/v1alpha1/server_types.go
+++ b/apis/v1alpha1/server_types.go
@@ -25,6 +25,12 @@ type Game struct {
 	// The name of the game type to be created.
 	Name string `json:"name"`
 
+	// The version of the game to be used.
+	//
+	// +kubebuilder:default:=latest
+	// +optional
+	Version string `json:"version"`
+
 	// The software used to load mods into the game server.
 	// Vanilla will launch the game server as default without any mods.
 	//

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,8 +34,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	polarisv1alpha1 "ricochet/polaris/apis/v1alpha1"
-	"ricochet/polaris/internal/controller"
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
+	"github.com/RicochetStudios/polaris/internal/controller"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/config/crd/bases/polaris.ricochet_servers.yaml
+++ b/config/crd/bases/polaris.ricochet_servers.yaml
@@ -57,6 +57,10 @@ spec:
                   name:
                     description: The name of the game type to be created.
                     type: string
+                  version:
+                    default: latest
+                    description: The version of the game to be used.
+                    type: string
                 required:
                 - name
                 type: object
@@ -70,6 +74,9 @@ spec:
               network:
                 description: The network configuration for the server.
                 properties:
+                  address:
+                    description: The IP address of the server.
+                    type: string
                   type:
                     description: The type of network to be used for the server.
                     enum:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ricochet/polaris
+module github.com/RicochetStudios/polaris
 
 go 1.21.5
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -33,7 +33,7 @@ export GOMODCACHE GO111MODULE GOFLAGS GOPATH
 
 
 # Define overall configuration.
-readonly REPO="ricochet/polaris"
+readonly REPO="github.com/RicochetStudios/polaris"
 readonly APIS_DIR="apis"
 # Define the output package for the generated code.
 readonly OUTPUT_PKG="${REPO}/pkg/client"

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -43,7 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	polarisv1alpha1 "ricochet/polaris/apis/v1alpha1"
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
 )
 
 // ServerReconciler reconciles a Server object

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -26,7 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	polarisv1alpha1 "ricochet/polaris/apis/v1alpha1"
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
 )
 
 var _ = Describe("Server Controller", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -35,7 +35,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	polarisv1alpha1 "ricochet/polaris/apis/v1alpha1"
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -20,8 +20,8 @@ package versioned
 import (
 	"fmt"
 	"net/http"
-	polarisv1alpha1 "ricochet/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -18,10 +18,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "ricochet/polaris/pkg/client/clientset/versioned"
-	polarisv1alpha1 "ricochet/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1"
-	fakepolarisv1alpha1 "ricochet/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake"
-
+	clientset "github.com/RicochetStudios/polaris/pkg/client/clientset/versioned"
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1"
+	fakepolarisv1alpha1 "github.com/RicochetStudios/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -18,8 +18,7 @@ limitations under the License.
 package fake
 
 import (
-	polarisv1alpha1 "ricochet/polaris/apis/v1alpha1"
-
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -18,8 +18,7 @@ limitations under the License.
 package scheme
 
 import (
-	polarisv1alpha1 "ricochet/polaris/apis/v1alpha1"
-
+	polarisv1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/apis_client.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/apis_client.go
@@ -19,9 +19,9 @@ package v1alpha1
 
 import (
 	"net/http"
-	v1alpha1 "ricochet/polaris/apis/v1alpha1"
-	"ricochet/polaris/pkg/client/clientset/versioned/scheme"
 
+	v1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
+	"github.com/RicochetStudios/polaris/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_apis_client.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_apis_client.go
@@ -18,8 +18,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "ricochet/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1"
-
+	v1alpha1 "github.com/RicochetStudios/polaris/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_server.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_server.go
@@ -19,8 +19,8 @@ package fake
 
 import (
 	"context"
-	v1alpha1 "ricochet/polaris/apis/v1alpha1"
 
+	v1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/server.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/server.go
@@ -19,10 +19,10 @@ package v1alpha1
 
 import (
 	"context"
-	v1alpha1 "ricochet/polaris/apis/v1alpha1"
-	scheme "ricochet/polaris/pkg/client/clientset/versioned/scheme"
 	"time"
 
+	v1alpha1 "github.com/RicochetStudios/polaris/apis/v1alpha1"
+	scheme "github.com/RicochetStudios/polaris/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"ricochet/polaris/test/utils"
+	"github.com/RicochetStudios/polaris/test/utils"
 )
 
 const namespace = "polaris-system"


### PR DESCRIPTION
This simply adds them to the spec, but does not add the functionality to them yet.

In addition, the module path has been corrected, which should fix the import error.

Closes #28