### PR TITLE
Ignore go.mod and go.sum in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: generate and format code"
+          # Ignore file changes in the root directory.
+          file_pattern: '**/**'
 
   test:
     name: test


### PR DESCRIPTION
Don't modify go.mod and go.sum to fix dependabot PRs